### PR TITLE
chore: change from "in" to "at"

### DIFF
--- a/apps/creatives/src/components/Projects.tsx
+++ b/apps/creatives/src/components/Projects.tsx
@@ -26,7 +26,7 @@ const projects = [
   {
     name: "GDSC USLS",
     description:
-      "The official website of Google Developer Student Clubs in the University of St. La Salle.",
+      "The official website of Google Developer Student Clubs at the University of St. La Salle.",
     // thumbnail: gdscThumb,
     logo: gdscLogo,
     link: "https://gdsc-usls.live/",


### PR DESCRIPTION
Instead of saying "in the University of St. La Salle," say "at the University of St. La Salle." This is because the term "at" is more usually used to refer to specific locations, such as universities. It also implies that the website is associated with or hosted by the institution or university rather than being physically located on campus.