### PR TITLE
fix: body overflow not set back to auto from hidden on routes

### DIFF
--- a/apps/creatives/src/app/contact/page.tsx
+++ b/apps/creatives/src/app/contact/page.tsx
@@ -1,9 +1,21 @@
+"use client";
+
+import gsap from "gsap";
 import Image from "next/image";
 import { Container } from "~/components/ui";
 import { TfiArrowRight } from "react-icons/tfi";
 import gradientSide from "~/images/gradient-side.jpg";
+import { useLayoutEffect } from "react";
 
 export default function Contact() {
+  useLayoutEffect(() => {
+    const tl = gsap.timeline();
+
+    tl.to("body", {
+      overflowY: "auto",
+    });
+  });
+
   return (
     <section className="relative mb-80 mt-40 lg:mb-[30rem]">
       <Image

--- a/apps/creatives/src/app/services/page.tsx
+++ b/apps/creatives/src/app/services/page.tsx
@@ -1,15 +1,27 @@
+"use client";
+
+import gsap from "gsap";
 import Image from "next/image";
+import { useLayoutEffect } from "react";
 import { Container } from "~/components/ui";
 import gradientSide from "~/images/gradient-side.jpg";
 
 export default function Services() {
+  useLayoutEffect(() => {
+    const tl = gsap.timeline();
+
+    tl.to("body", {
+      overflowY: "auto",
+    });
+  });
+
   return (
     <section className="relative mb-80 mt-40 lg:mb-[30rem]">
       <Image
         src={gradientSide}
         quality={100}
         alt="bg image"
-        className="pointer-events-none absolute -top-24 md:-top-8 lg:-top-0 left-0 z-10 h-screen mix-blend-screen"
+        className="pointer-events-none absolute -top-24 left-0 z-10 h-screen mix-blend-screen md:-top-8 lg:-top-0"
       />
       <Container className="mt-12 space-y-8 sm:pl-12 md:space-y-10 md:pl-24 lg:space-y-14 xl:space-y-16 2xl:pl-48">
         <h2 className="bg-gradient-to-t from-[#c6c7c7] to-white bg-clip-text text-2xl tracking-tight text-transparent sm:text-3xl md:text-4xl lg:text-5xl lg:leading-[1.1]">

--- a/apps/creatives/src/app/story/page.tsx
+++ b/apps/creatives/src/app/story/page.tsx
@@ -1,8 +1,20 @@
+"use client";
+
+import gsap from "gsap";
 import Image from "next/image";
+import { useLayoutEffect } from "react";
 import { Container } from "~/components/ui";
 import gradientSide from "~/images/gradient-side.jpg";
 
 export default function Story() {
+  useLayoutEffect(() => {
+    const tl = gsap.timeline();
+
+    tl.to("body", {
+      overflowY: "auto",
+    });
+  });
+
   return (
     <section className="relative mb-80 mt-40 flex flex-col gap-y-60 md:gap-y-72 lg:mb-[30rem] xl:gap-y-96">
       <Image


### PR DESCRIPTION
This updates the overflowY of body to auto when visiting each routes

```ts

  useLayoutEffect(() => {
    const tl = gsap.timeline();

    tl.to("body", {
      overflowY: "auto",
    });
  });

```